### PR TITLE
feat(grammar)!: add, rename and remove nodes, simplify grammar

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -9,6 +9,7 @@
 
 const NEWLINE = /\r?\n/;
 const WHITE_SPACE = /[ \t]/;
+const CHOICE_CHARACTER = /[^\]\r\n/]/;
 
 module.exports = grammar({
   name: 'editorconfig',
@@ -18,15 +19,10 @@ module.exports = grammar({
     $._integer_range_start,
   ],
 
-  inline: $ => [
-    $._eol,
-    $._line,
-  ],
-
   extras: _ => [WHITE_SPACE],
 
   rules: {
-    document: $ => seq(
+    editorconfig: $ => seq(
       optional($.preamble),
       repeat($.section),
     ),
@@ -37,33 +33,27 @@ module.exports = grammar({
 
     preamble: $ => repeat1($._line),
 
-    section: $ => seq($._section_header, repeat($._line)),
-
-    _section_header: $ => seq(
-      '[',
-      alias($._glob_expression, $.section_name),
-      ']',
-      $._eol,
+    section: $ => seq(
+      $.header,
+      repeat($._line),
     ),
+
+    header: $ => seq('[', $.section_name, ']', $._eol),
+
+    section_name: $ => $._glob_expression,
 
     // https://spec.editorconfig.org/#glob-expressions
     _glob_expression: $ => repeat1(choice(
-      $.character,
+      '/',
+      $.wildcard,
       $.integer_range,
-      $.path_separator,
       $.brace_expansion,
       $.character_choice,
       $.escaped_character,
-      $.wildcard_characters,
-      $.wildcard_any_characters,
-      $.wildcard_single_character,
+      /[^?*/\n{}\[\]]/,
     )),
 
-    wildcard_characters: _ => '*',
-    wildcard_any_characters: _ => '**',
-    wildcard_single_character: _ => '?',
-    path_separator: _ => '/',
-    character: _ => /[^?*/\n{}\[\]]/,
+    wildcard: _ => choice('*', '**', '?'),
 
     escaped_character: _ => /\\\W/,
 
@@ -74,7 +64,7 @@ module.exports = grammar({
         ',',
         $.expansion_string,
       )),
-      '}'
+      '}',
     ),
 
     expansion_string: $ => prec.left(repeat1(prec.right($._glob_expression))),
@@ -87,57 +77,38 @@ module.exports = grammar({
       '}',
     ),
 
+    character: _ => CHOICE_CHARACTER,
+
     character_choice: $ => seq(
       '[',
-      optional($.negation),
+      optional(token.immediate('!')),
       repeat1(choice(
         $.character_range,
         $.escaped_character,
-        alias(/[^\]\r\n/]/, $.character),
+        $.character,
       )),
       ']',
     ),
 
-    negation: _ => token.immediate('!'),
-
     character_range: $ => seq(
-      field('start', alias(/[^\]\r\n/]/, $.character)),
+      field('start', $.character),
       token.immediate('-'),
-      field('end', alias(token.immediate(/\w/), $.character)),
+      field('end', alias(token.immediate(CHOICE_CHARACTER), $.character)),
     ),
 
     pair: $ => seq(
-      field('key', $.identifier),
+      field('key', $.property),
       '=',
       token(repeat(WHITE_SPACE)), // Eat all the leading white-space
-      field('value', optional(choice(
-        $.unset,
-        $.unknown,
-        $.integer,
-        $.boolean,
-        $.charset,
-        $.end_of_line,
-        $.indent_style,
-        $.spelling_language,
-      ))),
+      field('value', optional($.string)),
       $._eol,
     ),
 
-    unset: _ => /unset/i,
-    integer: _ => /\d+/,
-    boolean: _ => /true|false|off/i,
-    end_of_line: _ => /lf|cr|crlf/i,
-    indent_style: _ => /space|tab/i,
-    spelling_language: _ => /[a-z]{2}(-[A-Z]{2})?/,
-    charset: _ => /latin1|utf-8|utf-16be|utf-16le|utf-8-bom/i,
-
     // Starts and ends with a non-whitespace character, with
     // any character (including withespace) in the middle.
-    identifier: _ => /[^\s=#;\[]([^\n\r=]*[^\s=])?/,
+    property: _ => /[^\s=#;\[]([^\n\r=]*[^\s=])?/,
 
-    // The spec allows the use of arbitrary values even if they are not supported
-    // so this capture is used as a fallback if no supported values match
-    unknown: _ => /\S([^\n\r]*\S)?/,
+    string: _ => /\S([^\n\r]*\S)?/,
 
     _eol: $ => choice(NEWLINE, $._end_of_file),
   },

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,48 +1,72 @@
 (comment) @comment
 
-(character) @constant
+(section_name) @markup.heading
 
-(section_name
-  (character) @type)
+(property) @property
 
-(expansion_string
-  (character) @type)
+(string) @string
 
-[
- "["
- "]"
- "{"
- "}"
-] @punctuation.bracket
-
-[
-  (path_separator)
-  ","
-] @punctuation.delimiter
-
-[
-  "-"
-  ".."
-  "="
-  (negation)
-  (wildcard_characters)
-  (wildcard_any_characters)
-  (wildcard_single_character)
-] @operator
+(character) @character
 
 (escaped_character) @string.special
 
-(pair
-  key: (identifier) @property
-  value: (_)? @string)
-
-(boolean) @boolean
 (integer) @number
 
 [
-  (unset)
-  (spelling_language)
-  (indent_style)
-  (end_of_line)
-  (charset)
-] @constant.builtin
+  "*"
+  "?"
+  "**"
+] @character.special
+
+[
+  "="
+  "!"
+] @operator
+
+[
+  ","
+  "-"
+  "/"
+  ".."
+] @punctuation.delimiter
+
+[
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+; Special values
+((pair
+  key: (property) @_key
+  value: (string) @string.special)
+  (#eq? @_key "indent_style")
+  (#any-of? @string.special "space" "tab"))
+
+((pair
+  key: (property) @_key
+  value: (string) @string.special)
+  (#eq? @_key "indent_size")
+  (#eq? @string.special "tab"))
+
+((pair
+  key: (property) @_key
+  value: (string) @string.special)
+  (#eq? @_key "end_of_line")
+  (#any-of? @string.special "lf" "cr" "crlf"))
+
+((pair
+  key: (property) @_key
+  value: (string) @string.special)
+  (#eq? @_key "charset")
+  (#any-of? @string.special "latin1" "utf-8" "utf-8-bom" "utf-16be" "utf-16le"))
+
+((string) @boolean
+  (#any-of? @boolean "true" "false" "off"))
+
+((string) @number
+  (#lua-match? @number "^[0-9]+$"))
+
+((string) @constant.builtin
+  (#eq? @constant.builtin "unset"))

--- a/test/corpus/braces.txt
+++ b/test/corpus/braces.txt
@@ -5,29 +5,26 @@ Simple brace expansions
 [*.{a,b,c}]
 [{s,a}c]
 ------------------------------------------------------
-(document
+
+(editorconfig
   (section
-    (section_name
-      (brace_expansion)))
+    (header
+      (section_name
+        (brace_expansion))))
   (section
-    (section_name
-      (wildcard_characters)
-      (character)
-      (brace_expansion
-        (expansion_string
-          (character))
-        (expansion_string
-          (character))
-        (expansion_string
-          (character)))))
+    (header
+      (section_name
+        (wildcard)
+        (brace_expansion
+          (expansion_string)
+          (expansion_string)
+          (expansion_string)))))
   (section
-    (section_name
-      (brace_expansion
-        (expansion_string
-          (character))
-        (expansion_string
-          (character)))
-      (character))))
+    (header
+      (section_name
+        (brace_expansion
+          (expansion_string)
+          (expansion_string))))))
 
 ======================================================
 Brace exapansions with empty strings
@@ -38,29 +35,28 @@ Brace exapansions with empty strings
 [{a,,b}]
 ------------------------------------------------------
 
-(document
+(editorconfig
   (section
-    (section_name
-      (brace_expansion
-        (expansion_string
-          (character)))))
+    (header
+      (section_name
+        (brace_expansion
+          (expansion_string)))))
   (section
-    (section_name
-      (brace_expansion
-        (expansion_string
-          (character)))))
+    (header
+      (section_name
+        (brace_expansion
+          (expansion_string)))))
   (section
-    (section_name
-      (brace_expansion
-        (expansion_string
-          (character)))))
+    (header
+      (section_name
+        (brace_expansion
+          (expansion_string)))))
   (section
-    (section_name
-      (brace_expansion
-        (expansion_string
-          (character))
-        (expansion_string
-          (character))))))
+    (header
+      (section_name
+        (brace_expansion
+          (expansion_string)
+          (expansion_string))))))
 
 ======================================================
 Brace expansion with escaped characters
@@ -69,23 +65,22 @@ Brace expansion with escaped characters
 [{a\}}]
 ------------------------------------------------------
 
-(document
+(editorconfig
   (section
-    (section_name
-      (brace_expansion
-        (expansion_string
-          (character)
-          (escaped_character))
-        (expansion_string
-          (escaped_character))
-        (expansion_string
-          (character)))))
+    (header
+      (section_name
+        (brace_expansion
+          (expansion_string
+            (escaped_character))
+          (expansion_string
+            (escaped_character))
+          (expansion_string)))))
   (section
-    (section_name
-      (brace_expansion
-        (expansion_string
-          (character)
-          (escaped_character))))))
+    (header
+      (section_name
+        (brace_expansion
+          (expansion_string
+            (escaped_character)))))))
 
 ======================================================
 Brace expansions with nested expressions
@@ -93,39 +88,29 @@ Brace expansions with nested expressions
 [/a/**{b/{c,{1..9}},e[bc]/{f?.?*,g}}]
 ------------------------------------------------------
 
-(document
+(editorconfig
   (section
-    (section_name
-      (path_separator)
-      (character)
-      (path_separator)
-      (wildcard_any_characters)
-      (brace_expansion
-        (expansion_string
-          (character)
-          (path_separator)
-          (brace_expansion
-            (expansion_string
+    (header
+      (section_name
+        (wildcard)
+        (brace_expansion
+          (expansion_string
+            (brace_expansion
+              (expansion_string)
+              (expansion_string
+                (integer_range
+                  start: (integer)
+                  end: (integer)))))
+          (expansion_string
+            (character_choice
+              (character)
               (character))
-            (expansion_string
-              (integer_range
-                start: (integer)
-                end: (integer)))))
-        (expansion_string
-          (character)
-          (character_choice
-            (character)
-            (character))
-          (path_separator)
-          (brace_expansion
-            (expansion_string
-              (character)
-              (wildcard_single_character)
-              (character)
-              (wildcard_single_character)
-              (wildcard_characters))
-            (expansion_string
-              (character))))))))
+            (brace_expansion
+              (expansion_string
+                (wildcard)
+                (wildcard)
+                (wildcard))
+              (expansion_string))))))))
 
 ======================================================
 Integer Range
@@ -135,27 +120,32 @@ Integer Range
 [{-10..2}]
 [{-1..-20}]
 ------------------------------------------------------
-(document
+
+(editorconfig
   (section
-    (section_name
-      (integer_range
-        start: (integer)
-        end: (integer))))
+    (header
+      (section_name
+        (integer_range
+          start: (integer)
+          end: (integer)))))
   (section
-    (section_name
-      (integer_range
-        start: (integer)
-        end: (integer))))
+    (header
+      (section_name
+        (integer_range
+          start: (integer)
+          end: (integer)))))
   (section
-    (section_name
-      (integer_range
-        start: (integer)
-        end: (integer))))
+    (header
+      (section_name
+        (integer_range
+          start: (integer)
+          end: (integer)))))
   (section
-    (section_name
-      (integer_range
-        start: (integer)
-        end: (integer)))))
+    (header
+      (section_name
+        (integer_range
+          start: (integer)
+          end: (integer))))))
 
 ======================================================
 Brace expansions with integers
@@ -166,39 +156,27 @@ Brace expansions with integers
 [{30,-44,5}]
 ------------------------------------------------------
 
-(document
+(editorconfig
   (section
-    (section_name
-      (brace_expansion
-        (expansion_string
-          (character)
-          (character)
-          (character)))))
+    (header
+      (section_name
+        (brace_expansion
+          (expansion_string)))))
   (section
-    (section_name
-      (brace_expansion
-        (expansion_string
-          (character)
-          (character)
-          (character)))))
+    (header
+      (section_name
+        (brace_expansion
+          (expansion_string)))))
   (section
-    (section_name
-      (brace_expansion
-        (expansion_string
-          (character)
-          (character)
-          (character))
-        (expansion_string
-          (character)))))
+    (header
+      (section_name
+        (brace_expansion
+          (expansion_string)
+          (expansion_string)))))
   (section
-    (section_name
-      (brace_expansion
-        (expansion_string
-          (character)
-          (character))
-        (expansion_string
-          (character)
-          (character)
-          (character))
-        (expansion_string
-          (character))))))
+    (header
+      (section_name
+        (brace_expansion
+          (expansion_string)
+          (expansion_string)
+          (expansion_string))))))

--- a/test/corpus/brackets.txt
+++ b/test/corpus/brackets.txt
@@ -6,25 +6,28 @@ Character choice
 [[[\]\-]]
 ------------------------------------------------------
 
-(document
+(editorconfig
   (section
-    (section_name
-      (character_choice
-        (character)
-        (character)
-        (character))))
+    (header
+      (section_name
+        (character_choice
+          (character)
+          (character)
+          (character)))))
   (section
-    (section_name
-      (character_choice
-        (character)
-        (character)
-        (character))))
+    (header
+      (section_name
+        (character_choice
+          (character)
+          (character)
+          (character)))))
   (section
-    (section_name
-      (character_choice
-        (character)
-        (escaped_character)
-        (escaped_character)))))
+    (header
+      (section_name
+        (character_choice
+          (character)
+          (escaped_character)
+          (escaped_character))))))
 
 ======================================================
 Character choice (Negated)
@@ -34,28 +37,28 @@ Character choice (Negated)
 [[![\]\-]]
 ------------------------------------------------------
 
-(document
+(editorconfig
   (section
-    (section_name
-      (character_choice
-        (negation)
-        (character)
-        (character)
-        (character))))
+    (header
+      (section_name
+        (character_choice
+          (character)
+          (character)
+          (character)))))
   (section
-    (section_name
-      (character_choice
-        (negation)
-        (character)
-        (character)
-        (character))))
+    (header
+      (section_name
+        (character_choice
+          (character)
+          (character)
+          (character)))))
   (section
-    (section_name
-      (character_choice
-        (negation)
-        (character)
-        (escaped_character)
-        (escaped_character)))))
+    (header
+      (section_name
+        (character_choice
+          (character)
+          (escaped_character)
+          (escaped_character))))))
 
 ======================================================
 Character range
@@ -66,35 +69,39 @@ Character range
 [[sa-e0]]
 ------------------------------------------------------
 
-(document
+(editorconfig
   (section
-    (section_name
-      (character_choice
-        (character_range
-          start: (character)
-          end: (character)))))
+    (header
+      (section_name
+        (character_choice
+          (character_range
+            start: (character)
+            end: (character))))))
   (section
-    (section_name
-      (character_choice
-        (character)
-        (character_range
-          start: (character)
-          end: (character)))))
+    (header
+      (section_name
+        (character_choice
+          (character)
+          (character_range
+            start: (character)
+            end: (character))))))
   (section
-    (section_name
-      (character_choice
-        (character_range
-          start: (character)
-          end: (character))
-        (character))))
+    (header
+      (section_name
+        (character_choice
+          (character_range
+            start: (character)
+            end: (character))
+          (character)))))
   (section
-    (section_name
-      (character_choice
-        (character)
-        (character_range
-          start: (character)
-          end: (character))
-        (character)))))
+    (header
+      (section_name
+        (character_choice
+          (character)
+          (character_range
+            start: (character)
+            end: (character))
+          (character))))))
 
 ======================================================
 Character range (Negated)
@@ -105,39 +112,39 @@ Character range (Negated)
 [[!sa-e0]]
 ------------------------------------------------------
 
-(document
+(editorconfig
   (section
-    (section_name
-      (character_choice
-        (negation)
-        (character_range
-          start: (character)
-          end: (character)))))
+    (header
+      (section_name
+        (character_choice
+          (character_range
+            start: (character)
+            end: (character))))))
   (section
-    (section_name
-      (character_choice
-        (negation)
-        (character)
-        (character_range
-          start: (character)
-          end: (character)))))
+    (header
+      (section_name
+        (character_choice
+          (character)
+          (character_range
+            start: (character)
+            end: (character))))))
   (section
-    (section_name
-      (character_choice
-        (negation)
-        (character_range
-          start: (character)
-          end: (character))
-        (character))))
+    (header
+      (section_name
+        (character_choice
+          (character_range
+            start: (character)
+            end: (character))
+          (character)))))
   (section
-    (section_name
-      (character_choice
-        (negation)
-        (character)
-        (character_range
-          start: (character)
-          end: (character))
-        (character)))))
+    (header
+      (section_name
+        (character_choice
+          (character)
+          (character_range
+            start: (character)
+            end: (character))
+          (character))))))
 
 ======================================================
 Empty character choice
@@ -146,6 +153,8 @@ Empty character choice
 [[]]
 ------------------------------------------------------
 
+
+
 ======================================================
 Empty character choice (Negated)
 :error
@@ -153,9 +162,13 @@ Empty character choice (Negated)
 [[!]]
 ------------------------------------------------------
 
+
+
 ======================================================
 Unescaped hyphen
 :error
 ======================================================
 [[a-]]
 ------------------------------------------------------
+
+

--- a/test/corpus/main.txt
+++ b/test/corpus/main.txt
@@ -15,24 +15,25 @@ insert_final_newline = true
 
 ------------------------------------------------------
 
-(document
+(editorconfig
   (preamble
     (comment)
     (comment)
     (pair
-      key: (identifier)
-      value: (boolean))
+      key: (property)
+      value: (string))
     (comment))
   (section
-    (section_name
-      (wildcard_characters))
+    (header
+      (section_name
+        (wildcard)))
     (pair
-      key: (identifier)
-      value: (end_of_line))
+      key: (property)
+      value: (string))
     (comment)
     (pair
-      key: (identifier)
-      value: (boolean))))
+      key: (property)
+      value: (string))))
 
 ======================================================
 Supported values
@@ -62,65 +63,65 @@ max_line_length = off
 spelling_language = es
 ------------------------------------------------------
 
-(document
+(editorconfig
   (preamble
     (pair
-      key: (identifier)
-      value: (boolean)))
+      key: (property)
+      value: (string)))
   (section
-    (section_name
-      (character))
+    (header
+      (section_name))
     (pair
-      key: (identifier)
-      value: (end_of_line))
+      key: (property)
+      value: (string))
     (pair
-      key: (identifier)
-      value: (boolean))
+      key: (property)
+      value: (string))
     (pair
-      key: (identifier)
-      value: (boolean))
+      key: (property)
+      value: (string))
     (pair
-      key: (identifier)
-      value: (charset))
+      key: (property)
+      value: (string))
     (pair
-      key: (identifier)
-      value: (spelling_language))
+      key: (property)
+      value: (string))
     (pair
-      key: (identifier)
-      value: (integer)))
+      key: (property)
+      value: (string)))
   (section
-    (section_name
-      (character))
+    (header
+      (section_name))
     (pair
-      key: (identifier)
-      value: (end_of_line))
+      key: (property)
+      value: (string))
     (pair
-      key: (identifier)
-      value: (indent_style))
+      key: (property)
+      value: (string))
     (pair
-      key: (identifier)
-      value: (boolean)))
+      key: (property)
+      value: (string)))
   (section
-    (section_name
-      (character))
+    (header
+      (section_name))
     (pair
-      key: (identifier)
-      value: (end_of_line))
+      key: (property)
+      value: (string))
     (pair
-      key: (identifier)
-      value: (indent_style))
+      key: (property)
+      value: (string))
     (pair
-      key: (identifier)
-      value: (integer)))
+      key: (property)
+      value: (string)))
   (section
-    (section_name
-      (character))
+    (header
+      (section_name))
     (pair
-      key: (identifier)
-      value: (boolean))
+      key: (property)
+      value: (string))
     (pair
-      key: (identifier)
-      value: (spelling_language))))
+      key: (property)
+      value: (string))))
 
 ======================================================
 Unsupported keys and values with spaces
@@ -135,26 +136,26 @@ key = # this is not a comment
 
 ------------------------------------------------------
 
-(document
+(editorconfig
   (section
-    (section_name
-      (character))
+    (header
+      (section_name))
     (comment)
     (pair
-      key: (identifier)
-      value: (unknown))
+      key: (property)
+      value: (string))
     (pair
-      key: (identifier)
-      value: (unknown))
+      key: (property)
+      value: (string))
     (pair
-      key: (identifier)
-      value: (unknown))
+      key: (property)
+      value: (string))
     (pair
-      key: (identifier)
-      value: (charset))
+      key: (property)
+      value: (string))
     (pair
-      key: (identifier)
-      value: (unknown))))
+      key: (property)
+      value: (string))))
 
 ======================================================
 Properties with an empty value
@@ -166,20 +167,21 @@ b =
  d =  
 spaces =     
 ------------------------------------------------------
-(document
+
+(editorconfig
   (section
-    (section_name
-      (character))
+    (header
+      (section_name))
     (pair
-      key: (identifier))
+      key: (property))
     (pair
-      key: (identifier))
+      key: (property))
     (pair
-      key: (identifier))
+      key: (property))
     (pair
-      key: (identifier))
+      key: (property))
     (pair
-      key: (identifier))))
+      key: (property))))
 
 ======================================================
 Comments
@@ -196,25 +198,25 @@ key ; = # value
 #
 ------------------------------------------------------
 
-(document
+(editorconfig
   (preamble
     (comment)
     (comment))
   (section
-    (section_name
-      (character))
+    (header
+      (section_name))
     (comment)
     (pair
-      key: (identifier)
-      value: (unknown))
+      key: (property)
+      value: (string))
     (comment))
   (section
-    (section_name
-      (character))
+    (header
+      (section_name))
     (comment)
     (pair
-      key: (identifier)
-      value: (unknown))
+      key: (property)
+      value: (string))
     (comment)))
 
 ======================================================
@@ -228,22 +230,22 @@ indent_style = sPAce
 
 ------------------------------------------------------
 
-(document
+(editorconfig
   (section
-    (section_name
-      (character))
+    (header
+      (section_name))
     (pair
-      key: (identifier)
-      value: (charset))
+      key: (property)
+      value: (string))
     (pair
-      key: (identifier)
-      value: (end_of_line))
+      key: (property)
+      value: (string))
     (pair
-      key: (identifier)
-      value: (boolean))
+      key: (property)
+      value: (string))
     (pair
-      key: (identifier)
-      value: (indent_style))))
+      key: (property)
+      value: (string))))
 
 ======================================================
 Directory Separator
@@ -252,36 +254,28 @@ Directory Separator
 [a/b]
 [/a/b]
 ------------------------------------------------------
-(document
+
+(editorconfig
   (section
-    (section_name
-      (character)
-      (path_separator)))
+    (header
+      (section_name)))
   (section
-    (section_name
-      (character)
-      (path_separator)
-      (character)))
+    (header
+      (section_name)))
   (section
-    (section_name
-      (path_separator)
-      (character)
-      (path_separator)
-      (character))))
+    (header
+      (section_name))))
 
 ======================================================
 Back slash
 ======================================================
 [a\b\c]
 ------------------------------------------------------
-(document
+
+(editorconfig
   (section
-    (section_name
-      (character)
-      (character)
-      (character)
-      (character)
-      (character))))
+    (header
+      (section_name))))
 
 ======================================================
 Wildcards
@@ -291,39 +285,28 @@ Wildcards
 [src/**/*.c]
 [\*\?]
 ------------------------------------------------------
-(document
+
+(editorconfig
   (section
-    (section_name
-      (wildcard_characters)
-      (character)
-      (character)
-      (character)))
+    (header
+      (section_name
+        (wildcard))))
   (section
-    (section_name
-      (wildcard_characters)
-      (character)
-      (character)
-      (character)
-      (character)
-      (character)
-      (wildcard_single_character)
-      (wildcard_single_character)))
+    (header
+      (section_name
+        (wildcard)
+        (wildcard)
+        (wildcard))))
   (section
-    (section_name
-      (character)
-      (character)
-      (character)
-      (path_separator)
-      (wildcard_any_characters)
-      (path_separator)
-      (wildcard_characters)
-      (character)
-      (character)))
+    (header
+      (section_name
+        (wildcard)
+        (wildcard))))
   (section
-    (section_name
-      (escaped_character)
-      (escaped_character)))
-  )
+    (header
+      (section_name
+        (escaped_character)
+        (escaped_character)))))
 
 ======================================================
 Without ending new line
@@ -331,18 +314,19 @@ Without ending new line
 root = true
 ------------------------------------------------------
 
-(document
+(editorconfig
   (preamble
     (pair
-      key: (identifier)
-      value: (boolean))))
+      key: (property)
+      value: (string))))
 
 ======================================================
 Empty file
 ======================================================
 
 ------------------------------------------------------
-(document)
+
+(editorconfig)
 
 ======================================================
 New line in section name
@@ -353,12 +337,16 @@ l]
 end_of_line = lf
 ------------------------------------------------------
 
+
+
 ======================================================
 Empty section name
 :error
 ======================================================
 []
 ------------------------------------------------------
+
+
 
 ======================================================
 Characters after section header
@@ -367,6 +355,8 @@ Characters after section header
 [a] key = value
 ------------------------------------------------------
 
+
+
 ======================================================
 Property without '=' and value
 :error
@@ -374,9 +364,13 @@ Property without '=' and value
 property
 ------------------------------------------------------
 
+
+
 ======================================================
 Comment after section header
 :error
 ======================================================
 [a] # Comment
 ------------------------------------------------------
+
+


### PR DESCRIPTION
- Values are now just a `(string)` node, parsing special values is delegated to the queries.
- hide (character) node, but not in (character_class)
- Rename
  - document -> editorconfig
  - identifier -> property
  - wildcard_* -> wildcard
  - negation -> "!"
  - path_separator -> "/"